### PR TITLE
Add support for RequiresMountsFor parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ systemd-journald is a system service that collects and stores logging data
 * **cpuquota**: Assign the specified CPU time quota to the processes executed. Takes a percentage value, suffixed with "%". The percentage specifies how much CPU time the unit shall get at maximum, relative to the total CPU time available on one CPU (default: undef)
 * **tasksmax**: Specify the maximum number of tasks that may be created in the unit. (default: undef)
 * **partof**: Specify if service has dependency. Similar to Requires= When systemd stops or restarts the units listed here, the action is propagated to this unit.
+- **requires_mounts_for**: Array of absolute paths the unit is dependent on. Automatically adds dependencies of type Requires= and After= for all mount units required to access the specified path. (default: [])
 
 #### systemd::service::dropin
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -72,6 +72,7 @@ define systemd::service (
                           $allow_isolate                   = undef,
                           $condition_path_is_symbolic_link = undef,
                           $default_dependencies            = undef,
+                          $requires_mounts_for             = [],
                         ) {
 
   if($type!=undef and $forking==true)

--- a/manifests/service/dropin.pp
+++ b/manifests/service/dropin.pp
@@ -74,6 +74,7 @@ define systemd::service::dropin (
                                   $allow_isolate                   = undef,
                                   $condition_path_is_symbolic_link = undef,
                                   $default_dependencies            = undef,
+                                  $requires_mounts_for             = [],
                                 ) {
 
   # if($restart!=undef)

--- a/templates/section/unit.erb
+++ b/templates/section/unit.erb
@@ -20,6 +20,9 @@ Conflicts=<%= @conflicts.join(' ') %>
 <% if @requires.any? -%>
 Requires=<%= @requires.join(' ') %>
 <% end -%>
+<% if @requires_mounts_for.any? -%>
+RequiresMountsFor=<%= @requires_mounts_for.join(' ') %>
+<% end -%>
 <% if @binds_to.any? -%>
 BindsTo=<%= @binds_to.join(' ') %>
 <% end -%>


### PR DESCRIPTION
Add support for RequiresMountsFor unit parameter that allows for making
a unit dependent on a specific mount point.